### PR TITLE
Some code enhancements

### DIFF
--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -16,9 +16,10 @@ Configure the add-on via your Home Assistant front-end under **Supervisor (Hass.
 
 | Parameter | Description |
 |-----------|-------------|
-| performance_check | boolean to enable or disable the execution of performance check at startup
+| performance_check | flag to enable or disable the execution of performance check at startup
 | hdd_path | path to drive to monitor
 | check_period | interval in minutes / how often to read temperature
+| debug | flag to enable or disable debugging. Activate this if you want to debug which property from the JSON output of `smartctl` you want to be merged to the sensor.
 | output_file | log file
 | attributes_property | attribute you want to merge with the attributes in your sensor. Check the `output_file` for the available properties.
 

--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -12,22 +12,19 @@ At start add-on runs PiBenchmarks https://jamesachambers.com/raspberry-pi-storag
 
 Configure the add-on via your Home Assistant front-end under **Supervisor (Hass.io) → Dashboard → HDD Tools**.
 
-The configuration:
+### Configuration parameters
 
-- hdd_path - path to drive to monitor
-- check_period - interval in minutes / how often to read temperature
-- output_file - log file
+| Parameter | Description |
+|-----------|-------------|
+| performance_check | boolean to enable or disable the execution of performance check at startup
+| hdd_path | path to drive to monitor
+| check_period | interval in minutes / how often to read temperature
+| output_file | log file
+| attributes_property | attribute you want to merge with the attributes in your sensor. Check the `output_file` for the available properties.
 
 ## Notes
 
 Addon reguires Protection Mode to be disabled to access S.M.A.R.T data
-
-<h3>Update History</h3>
-
-<h4>17.05.2020</h4>
-<ul>
-  <li>Added PiBenchmarks performance test</li>
-</ul>
 
 ## Credits
 

--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -16,6 +16,8 @@ Configure the add-on via your Home Assistant front-end under **Supervisor (Hass.
 
 | Parameter | Description |
 |-----------|-------------|
+| sensor_name | Name for the sensor which is exposed to home-assistant
+| friendly_name | Friendly name for the sensor which is exposed to home-assistant
 | performance_check | flag to enable or disable the execution of performance check at startup
 | hdd_path | path to drive to monitor
 | check_period | interval in minutes / how often to read temperature

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -1,6 +1,6 @@
 {
   "name": "HDD Tools",
-  "version": "0.44",
+  "version": "0.45",
   "slug": "hdd_tools",
   "description": "HDD Tools provides S.M.A.R.T information",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
@@ -11,13 +11,17 @@
   "full_access": true,
   "homeassistant_api": true,
   "options": {
-      "hdd_path": "/dev/sda",  
+      "performance_check": false,
+      "hdd_path": "/dev/sda",
       "check_period": 1,
-      "output_file": "temp.log"   
+      "output_file": "temp.log",
+      "attributes_property": ""
     },
   "schema": {
+      "performance_check": "bool",
       "hdd_path": "str",
       "check_period": "int(1,60)",
-      "output_file": "str"
+      "output_file": "str",
+      "attributes_property": "str"
     }
 }

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -11,14 +11,18 @@
   "full_access": true,
   "homeassistant_api": true,
   "options": {
-      "performance_check": false,
+      "sensor_name": "sensor.hdd_temp",
+      "friendly_name": "Hdd Temp",
       "hdd_path": "/dev/sda",
       "check_period": 1,
-      "debug": false,
       "output_file": "temp.log",
-      "attributes_property": ""
-    },
+      "debug": false,
+      "attributes_property": "",
+      "performance_check": false
+  },
   "schema": {
+      "sensor_name": "str",
+      "friendly_name": "str",
       "performance_check": "bool",
       "hdd_path": "str",
       "check_period": "int(1,60)",

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -14,6 +14,7 @@
       "performance_check": false,
       "hdd_path": "/dev/sda",
       "check_period": 1,
+      "debug": false,
       "output_file": "temp.log",
       "attributes_property": ""
     },
@@ -21,6 +22,7 @@
       "performance_check": "bool",
       "hdd_path": "str",
       "check_period": "int(1,60)",
+      "debug": "bool",
       "output_file": "str",
       "attributes_property": "str"
     }

--- a/hdd_tools/data/main.sh
+++ b/hdd_tools/data/main.sh
@@ -16,7 +16,7 @@ SENSOR_DATA='{"state": "'"$CURRENT_TEMPERATURE"'", "attributes": {"unit_of_measu
 
 if ! [ -z "$ATTRIBUTES_PROPERTY" ]; then
     ATTRIBUTES=$(echo $SMARTCTL_OUTPUT | jq -e --raw-output ".${ATTRIBUTES_PROPERTY}" || echo "{}")
-    SENSOR_DATA=$(echo $SENSOR_DATA | jq -n ".attributes += $ATTRIBUTES")
+    SENSOR_DATA=$(echo $SENSOR_DATA | jq ".attributes += $ATTRIBUTES")
 fi
 
 echo "[$(date)][Info] Sensor value: $CURRENT_TEMPERATURE°"

--- a/hdd_tools/data/main.sh
+++ b/hdd_tools/data/main.sh
@@ -1,17 +1,21 @@
 CONFIG_PATH=/data/options.json
 
 HDD_PATH="$(jq --raw-output '.hdd_path' $CONFIG_PATH)"
+DEBUG="$(jq --raw-output '.debug' $CONFIG_PATH)"
 OUTPUT_FILE="$(jq --raw-output '.output_file' $CONFIG_PATH)"
 ATTRIBUTES_PROPERTY="$(jq --raw-output '.attributes_property' $CONFIG_PATH)"
 
 SMARTCTL_OUTPUT=$(/usr/sbin/smartctl -a $HDD_PATH --json)
-echo "$SMARTCTL_OUTPUT" > /share/hdd_tools/${OUTPUT_FILE}
+
+if [ "$DEBUG" = "true" ]; then
+    echo "$SMARTCTL_OUTPUT" > /share/hdd_tools/${OUTPUT_FILE}
+fi
 
 CURRENT_TEMPERATURE=$(echo $SMARTCTL_OUTPUT | jq --raw-output '.temperature.current')
 SENSOR_DATA='{"state": "'"$CURRENT_TEMPERATURE"'", "attributes": {"unit_of_measurement":"°C","friendly_name":"HDD Temperature"}}'
 
 if ! [ -z "$ATTRIBUTES_PROPERTY" ]; then
-    ATTRIBUTES=$(echo $SMARTCTL_OUTPUT | jq -e --raw-output '.$ATTRIBUTES_PROPERTY' || echo "{}")
+    ATTRIBUTES=$(echo $SMARTCTL_OUTPUT | jq -e --raw-output ".${ATTRIBUTES_PROPERTY}" || echo "{}")
     SENSOR_DATA=$(echo $SENSOR_DATA | jq -n ".attributes += $ATTRIBUTES")
 fi
 

--- a/hdd_tools/data/main.sh
+++ b/hdd_tools/data/main.sh
@@ -2,21 +2,25 @@ CONFIG_PATH=/data/options.json
 
 HDD_PATH="$(jq --raw-output '.hdd_path' $CONFIG_PATH)"
 OUTPUT_FILE="$(jq --raw-output '.output_file' $CONFIG_PATH)"
+ATTRIBUTES_PROPERTY="$(jq --raw-output '.attributes_property' $CONFIG_PATH)"
 
-SMARTCTL_OUTPUT=$(/usr/sbin/smartctl -a $HDD_PATH)
+SMARTCTL_OUTPUT=$(/usr/sbin/smartctl -a $HDD_PATH --json)
 echo "$SMARTCTL_OUTPUT" > /share/hdd_tools/${OUTPUT_FILE}
 
-ATTRIBUTES=$(echo "$SMARTCTL_OUTPUT" | egrep -o '^[0-9 ]+.*[0-9]+$' | awk '{print "\"" $2 "\":\"" $(NF) "\"," }' | awk '{print tolower($0)}' | tr -d '\n') 
-MAIN_VALUE=$(echo "$SMARTCTL_OUTPUT" | grep Temperature_Celsius | awk '{print $(NF)}')
-API_CALL_BODY='{"state": "'"$MAIN_VALUE"'", "attributes": {"unit_of_measurement":"°C","friendly_name":"Hdd Temp",'"${ATTRIBUTES::-1}"'}}'
+CURRENT_TEMPERATURE=$(echo $SMARTCTL_OUTPUT | jq --raw-output '.temperature.current')
+SENSOR_DATA='{"state": "'"$CURRENT_TEMPERATURE"'", "attributes": {"unit_of_measurement":"°C","friendly_name":"HDD Temperature"}}'
 
-echo "[$(date)][Info] Sensor value: $MAIN_VALUE°"
-#echo "[$(date)][Debug] API call body: $API_CALL_BODY" > /proc/1/fd/1 2>/proc/1/fd/2
+if ! [ -z "$ATTRIBUTES_PROPERTY" ]; then
+    ATTRIBUTES=$(echo $SMARTCTL_OUTPUT | jq -e --raw-output '.$ATTRIBUTES_PROPERTY' || echo "{}")
+    SENSOR_DATA=$(echo $SENSOR_DATA | jq -n ".attributes += $ATTRIBUTES")
+fi
+
+echo "[$(date)][Info] Sensor value: $CURRENT_TEMPERATURE°"
 
 curl -X POST -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
        -s \
        -o /dev/null \
        -H "Content-Type: application/json" \
-       -d "$API_CALL_BODY" \
+       -d "$SENSOR_DATA" \
        -w "[$(date)][Info] Sensor update response code: %{http_code}\n" \
-       http://supervisor/core/api/states/sensor.hdd_temp 
+       http://supervisor/core/api/states/sensor.system_disk

--- a/hdd_tools/run.sh
+++ b/hdd_tools/run.sh
@@ -4,6 +4,9 @@ echo "[$(date)][Info] HDD Tools start"
 
 CONFIG_PATH=/data/options.json
 
+PERFORMANCE_CHECK="$(jq --raw-output '.performance_check' $CONFIG_PATH)"
+echo "[$(date)][Info] Configuration - performance check enabled: $PERFORMANCE_CHECK"
+
 HDD_PATH="$(jq --raw-output '.hdd_path' $CONFIG_PATH)"
 echo "[$(date)][Info] Configuration - disk path: $HDD_PATH" 
 
@@ -11,7 +14,10 @@ CHECK_PERIOD="$(jq --raw-output '.check_period' $CONFIG_PATH)"
 echo "[$(date)][Info] Configuration - check period: $CHECK_PERIOD" 
 
 OUTPUT_FILE="$(jq --raw-output '.output_file' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - output file: $OUTPUT_FILE" 
+echo "[$(date)][Info] Configuration - output file: $OUTPUT_FILE"
+
+ATTRIBUTES_PROPERTY="$(jq --raw-output '.attributes_property' $CONFIG_PATH)"
+echo "[$(date)][Info] Configuration - attributes property: $ATTRIBUTES_PROPERTY"
 
 mkdir -p /share/hdd_tools/scripts/
 mkdir -p /share/hdd_tools/performance_test/
@@ -21,10 +27,12 @@ cp /opt/main.sh /share/hdd_tools/scripts/main.sh
 echo "[$(date)][Info] Init run"
 /share/hdd_tools/scripts/main.sh
 
-echo "[$(date)][Info] Run performance test"
-/share/hdd_tools/scripts/storage.sh /share/hdd_tools/performance_test/ > /share/hdd_tools/performance.log 2> /share/hdd_tools/performance.log
-cat /share/hdd_tools/performance.log | sed  -n '/Category/,$p'
-echo "[$(date)][Info] Performance test end"
+if [ "$PERFORMANCE_CHECK" = "true" ]; then
+    echo "[$(date)][Info] Run performance test"
+    /share/hdd_tools/scripts/storage.sh /share/hdd_tools/performance_test/ > /share/hdd_tools/performance.log 2> /share/hdd_tools/performance.log
+    cat /share/hdd_tools/performance.log | sed  -n '/Category/,$p'
+    echo "[$(date)][Info] Performance test end"
+fi
 
 echo "[$(date)][Info] Cron tab update"
 sed -i "s/TIME_TOKEN/$CHECK_PERIOD/g" /etc/cron.d/cron


### PR DESCRIPTION
Hey there,

first of all, thanks for this addon!
I've made several changes to the configuration and to the execution to improve compatibility aswell as extensible configuration.

I've tried to keep most of the configuration backwards compatible but the new `attributes_property` configuration is not BC compatible and thus, attributes are being omitted if not configured.

## So what has changed?

1. Changed smartctl output to JSON by using `--json` argument
2. Made sensor name configurable (`sensor_name`)
3. Made sensors "Friendly Name" configurable (`friendly_name`)
4. Added flag to enable/disable performance check during startup (`performance_check`)
5. Added flag to enable/disable debug mode (`debug`) which passes the `smartctl --json` output to the `output_file`
6. Added configurable JSON property to parse "attributes" from (`attributes_property`)

So the `attributes_property` is a property within the JSON output passed to `output_file` when `debug` is enabled.
In my case, this is `nvme_smart_health_information_log`. I think, this differs from setup to setup and thus I wanted to have that configurable.

To avoid unnecessary I/O (writes of the `output_file`), it is now skipped when `debug` is `false`.

In case this is being merged, I'll switch back to this addon but for now I am using my fork.