### PR TITLE
Add all unknown fields to the sensor

### DIFF
--- a/hdd_tools/data/main.sh
+++ b/hdd_tools/data/main.sh
@@ -24,7 +24,7 @@ if ! [ -z "$ATTRIBUTES_PROPERTY" ]; then
         object)
         ;;
         list)
-            ATTRIBUTES=$(echo $ATTRIBUTES | jq 'map({(.name): .raw.string | capture("^(?<value>[[:digit:]]+)").value | tonumber}) | add | with_entries(.key |= ascii_downcase)')
+            ATTRIBUTES=$(echo $ATTRIBUTES | jq 'map({(if .name == "Unknown_Attribute" then "Unknown_Attribute_" + (.id | tostring) else .name end): .raw.string | capture("^(?<value>[[:digit:]]+)").value | tonumber}) | add | with_entries(.key |= ascii_downcase)')
         ;;
         *)
             echo "[$(date)][ERROR] Unsupported attributes format \"$ATTRIBUTES_FORMAT\" given!"


### PR DESCRIPTION
Fixes: https://github.com/Draggon/hassio-hdd-tools/issues/1

Appends the ID of the sensor to each unknown field name. In this way we can add all the unknown fields of the SMART data.

Before:
![image](https://user-images.githubusercontent.com/2673520/104926097-01840200-59a0-11eb-84b9-8b772e3eafcd.png)

After:
![image](https://user-images.githubusercontent.com/2673520/104926296-427c1680-59a0-11eb-96f4-eb379b58cbf8.png)


I'm not good at `.sh` coding, so maybe are ways that are far better to do the same.