### PR TITLE
Add URL info

### DIFF
--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -3,6 +3,7 @@
   "version": "0.47",
   "slug": "hdd_tools",
   "description": "HDD Tools provides S.M.A.R.T information",
+  "url": "https://github.com/Draggon/hassio-hdd-tools",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
   "boot": "auto",


### PR DESCRIPTION
Fixes the link in Home Assistant addon information.

![image](https://user-images.githubusercontent.com/2673520/110805306-3f572580-8281-11eb-9e2d-1c48d9ae8760.png)
