### PR TITLE
Add nvme and other devices support

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,10 @@ attributes_property: ata_smart_attributes.table
 attributes_format: list
 ```
 
+## Notes
+
+For some devices, the addon reguires Protection Mode to be disabled to access S.M.A.R.T data. If your device is mapped as `/dev/sda` or `/dev/nvme0` it will work out of the box. If not, you will need to disable Protection Mode.
+
 ## Credits
 
 - https://www.smartmontools.org/

--- a/hdd_tools/CHANGELOG.md
+++ b/hdd_tools/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.48.0 - 2021-03-23
+
+### Added
+
+- Add support for `/dev/nvme0` out of the box
+- Add the option to disable _Protection Mode_ in _Home Assistant_ to support devices different than `/dev/sda0` and `/dev/nvme0`
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.47.0 - 2021-03-08
 
 ### Added

--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -597,7 +597,7 @@ attributes_format: list
 
 ## Notes
 
-Addon reguires Protection Mode to be disabled to access S.M.A.R.T data
+For some devices, the addon reguires Protection Mode to be disabled to access S.M.A.R.T data. If your device is mapped as `/dev/sda` or `/dev/nvme0` it will work out of the box. If not, you will need to disable Protection Mode.
 
 ## Credits
 

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -1,6 +1,6 @@
 {
   "name": "HDD Tools",
-  "version": "0.47",
+  "version": "0.48",
   "slug": "hdd_tools",
   "description": "HDD Tools provides S.M.A.R.T information",
   "url": "https://github.com/Draggon/hassio-hdd-tools",

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -8,8 +8,9 @@
   "startup": "application",
   "boot": "auto",
   "map": ["share:rw"],
-  "devices": ["/dev/sda"],
-  "privileged": ["SYS_RAWIO"],
+  "devices": ["/dev/sda", "/dev/nvme0"],
+  "privileged": ["SYS_ADMIN", "SYS_RAWIO"],
+  "full_access": true,
   "homeassistant": "2021.2.0",
   "homeassistant_api": true,
   "options": {


### PR DESCRIPTION
Fixes https://github.com/Draggon/hassio-hdd-tools/issues/10

This is a middle point between only support `/dev/sda` and need to add `full_access` for everybody.

At this moment, it only works for `/dev/sda`. With this changes, it will support `/dev/sda` and `/dev/nvme0` without disabling Protection Mode, and will work for any other disabling it.