### PR TITLE
Fix devices selection for everyone

### DIFF
--- a/hdd_tools/DOCS.md
+++ b/hdd_tools/DOCS.md
@@ -2,10 +2,6 @@
 <h1>HDD Tools Hass.io Add-on</h1>
 </div>
 
-## Notes
-
-For some devices, the addon reguires Protection Mode to be disabled to access S.M.A.R.T data. If your device is mapped as `/dev/sda` or `/dev/nvme0` it will work out of the box. If not, you will need to disable Protection Mode.
-
 ### Configuration parameters
 
 | Parameter | Description |

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -8,9 +8,7 @@
   "startup": "application",
   "boot": "auto",
   "map": ["share:rw"],
-  "devices": ["/dev/sda", "/dev/nvme0"],
   "privileged": ["SYS_ADMIN", "SYS_RAWIO"],
-  "full_access": true,
   "homeassistant": "2021.2.0",
   "homeassistant_api": true,
   "options": {
@@ -28,11 +26,11 @@
       "sensor_name": "match(^sensor\\.\\w*$)",
       "friendly_name": "str",
       "performance_check": "bool",
-      "hdd_path": "str",
+      "hdd_path": "device(subsystem=block)",
       "check_period": "int(1,60)",
       "debug": "bool",
       "output_file": "str",
       "attributes_property": "str",
-      "attributes_format": "match(^object|list$)"
+      "attributes_format": "list(object|list)"
     }
 }


### PR DESCRIPTION
It seems I've found a workaround for the device mapping, and we will have a score of 4 again in the addon. It seems to work for me, I don't know if others can test it too. Maybe @massive, @boesing or @redskinhu are you able to test this?

It seems that if we mark in the schema some parameter as `device`, it is automatically mapped into the addon. 

It shows too a list to be selected by the user if we use the IU form in the configuration (YAML form is available too), that is great for users that don't know nothing about /dev Linux mapping.

![image](https://user-images.githubusercontent.com/2673520/112328125-53097f80-8cb6-11eb-942f-9bb117167acc.png)

~~The only drawback is that the list is big, it shows all the devices. It can be filtered:~~
> ~~device / device(filter): Device filter can be following format: subsystem=TYPE i.e. subsystem=tty for serial devices.~~

~~But I have not found the correct subsystem to put. I have tested `disk` and `block` without luck. I'm not a Linux expert.~~