### PR TITLE
Reorder options, English and Spanish translations

### DIFF
--- a/hdd_tools/DOCS.md
+++ b/hdd_tools/DOCS.md
@@ -8,13 +8,13 @@
 |-----------|-------------|
 | sensor_name | Name for the sensor which is exposed to home-assistant
 | friendly_name | Friendly name for the sensor which is exposed to home-assistant
-| performance_check | flag to enable or disable the execution of performance check at startup
-| hdd_path | path to drive to monitor
-| check_period | interval in minutes / how often to read temperature
-| debug | flag to enable or disable debugging. Activate this if you want to debug which property from the JSON output of `smartctl` you want to be merged to the sensor.
-| output_file | log file
-| attributes_property | attribute you want to merge with the attributes in your sensor. Check the `output_file` for the available properties.
-| attributes_format | one of `object` or `list`. See more details [here](#attributes).
+| hdd_path | Path to drive to monitor
+| attributes_format | One of `object` or `list`. See more details [here](#attributes).
+| attributes_property | Attribute you want to merge with the attributes in your sensor. Check the `output_file` for the available properties.
+| check_period | Interval in minutes / how often to read temperature
+| performance_check | Flag to enable or disable the execution of performance check at startup
+| debug | Flag to enable or disable debugging. Activate this if you want to debug which property from the JSON output of `smartctl` you want to be merged to the sensor.
+| output_file | Log file
 
 ### Attributes
 

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -15,22 +15,22 @@
       "sensor_name": "sensor.hdd_temp",
       "friendly_name": "Hdd Temp",
       "hdd_path": "/dev/sda",
-      "check_period": 1,
-      "output_file": "temp.log",
-      "debug": false,
+      "attributes_format": "object",
       "attributes_property": "",
+      "check_period": 1,
       "performance_check": false,
-      "attributes_format": "object"
+      "debug": false,
+      "output_file": "temp.log"
   },
   "schema": {
       "sensor_name": "match(^sensor\\.\\w*$)",
       "friendly_name": "str",
-      "performance_check": "bool",
       "hdd_path": "device(subsystem=block)",
-      "check_period": "int(1,60)",
-      "debug": "bool",
-      "output_file": "str",
+      "attributes_format": "list(object|list)",
       "attributes_property": "str",
-      "attributes_format": "list(object|list)"
+      "check_period": "int(1,60)",
+      "performance_check": "bool",
+      "debug": "bool",
+      "output_file": "str"
     }
 }

--- a/hdd_tools/translations/en.yaml
+++ b/hdd_tools/translations/en.yaml
@@ -1,0 +1,29 @@
+configuration:
+  sensor_name:
+    name: Name of the sensor
+    description: Name for the sensor which is exposed to Home Assistant    
+  friendly_name:
+    name: Friendly name
+    description: Friendly name for the sensor which is exposed to Home Assistant
+  hdd_path:
+    name: Path of HDD
+    description: Path to drive to monitor
+  attributes_format:
+    name: Format of the attributes
+    description:  One of `object` or `list`. More details in the Documentation tab.
+  attributes_property:
+    name: Attributes property
+    description: Attribute you want to merge with the attributes in your sensor. Check the output file for the available properties.
+  check_period:
+    name: Check period
+    description: Interval in minutes / how often to read temperature
+  performance_check:
+    name: Performance check
+    description: Flag to enable or disable the execution of performance check at startup
+  debug:
+    name: Debug
+    description: Flag to enable or disable debugging. Activate this if you want to debug which property from the JSON output of smartctl you want to be merged to the sensor.
+  output_file:
+    name: Output file
+    description: Log file
+ 

--- a/hdd_tools/translations/es.yaml
+++ b/hdd_tools/translations/es.yaml
@@ -1,0 +1,19 @@
+configuration:
+  sensor_name:
+    name: Nombre del sensor
+  friendly_name:
+    name: Nombre amigable
+  hdd_path:
+    name: Descriptor del disco
+  attributes_format:
+    name: Formato de los atributos
+  attributes_property:
+    name: Propiedad con los atributos
+  check_period:
+    name: Intervalo de comprobación
+  performance_check:
+    name: Comprobar el rendimiento
+  debug:
+    name: Depuración
+  output_file:
+    name: Archivo de salida


### PR DESCRIPTION
This reorders the options in the yaml options file in what it seems to me a more logical way, grouping them.

It adds too an English "translation" into friendly names of the options and a Spanish translation too. I think this made the options page a little more friendly. They are only shown in the UI mode of the configuration.

Until now, Home Assistant does not add the descriptions of the parameters into UI, so they are there only as informative text.
