### PR TITLE
Option to update drives database

### DIFF
--- a/hdd_tools/DOCS.md
+++ b/hdd_tools/DOCS.md
@@ -12,6 +12,8 @@
 | attributes_format | One of `object` or `list`. See more details [here](#attributes).
 | attributes_property | Attribute you want to merge with the attributes in your sensor. Check the `output_file` for the available properties.
 | check_period | Interval in minutes / how often to read temperature
+| database_update | Flag to enable the update of the smartmontools drives database
+| database_update_period | Interval in hours / how often the drives database is updated
 | performance_check | Flag to enable or disable the execution of performance check at startup
 | debug | Flag to enable or disable debugging. Activate this if you want to debug which property from the JSON output of `smartctl` you want to be merged to the sensor.
 | output_file | Log file

--- a/hdd_tools/Dockerfile
+++ b/hdd_tools/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-RUN apk add --no-cache coreutils util-linux ncurses build-base make fio hdparm perl smartmontools vim apk-cron
+RUN apk add --no-cache coreutils util-linux ncurses build-base make fio hdparm perl smartmontools vim apk-cron gnupg
 
 # Copy cron file to the cron.d directory
 COPY data/cron /etc/cron.d/cron
@@ -12,6 +12,9 @@ COPY data/main.sh /opt/main.sh
 RUN chmod 0755 /opt/main.sh
 
 COPY data/storage.sh /opt/storage.sh
+RUN chmod 0755 /opt/storage.sh
+
+COPY data/database.sh /opt/database.sh
 RUN chmod 0755 /opt/storage.sh
 
 # Copy data for add-on

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -18,6 +18,8 @@
       "attributes_format": "object",
       "attributes_property": "",
       "check_period": 1,
+      "database_update": true,
+      "database_update_period": 168,
       "performance_check": false,
       "debug": false,
       "output_file": "temp.log"
@@ -29,6 +31,8 @@
       "attributes_format": "list(object|list)",
       "attributes_property": "str",
       "check_period": "int(1,60)",
+      "database_update": "bool",
+      "database_update_period": "int(1,5000)",
       "performance_check": "bool",
       "debug": "bool",
       "output_file": "str"

--- a/hdd_tools/data/cron
+++ b/hdd_tools/data/cron
@@ -1,2 +1,3 @@
-*/TIME_TOKEN * * * * /share/hdd_tools/scripts/main.sh > /proc/1/fd/1 2>/proc/1/fd/2
+*/SMART_TIME_TOKEN * * * * /share/hdd_tools/scripts/main.sh > /proc/1/fd/1 2>/proc/1/fd/2
+#* */DATABASE_TIME_TOKEN * * * /share/hdd_tools/scripts/database.sh > /proc/1/fd/1 2>/proc/1/fd/2
 #An empty line is required at the end of this file for a valid cron file.

--- a/hdd_tools/data/database.sh
+++ b/hdd_tools/data/database.sh
@@ -1,0 +1,5 @@
+
+echo "[$(date)][INFO] Updating drives database..."
+
+SMARTCTL_DATABASE_OUTPUT=$(/usr/sbin/update-smart-drivedb)
+echo "[$(date)][INFO] $SMARTCTL_DATABASE_OUTPUT"

--- a/hdd_tools/run.sh
+++ b/hdd_tools/run.sh
@@ -1,50 +1,65 @@
 #!/usr/bin/with-contenv bashio
 
-echo "[$(date)][Info] HDD Tools start"
+echo "[$(date)][INFO] HDD Tools start"
 
 CONFIG_PATH=/data/options.json
 
 PERFORMANCE_CHECK="$(jq --raw-output '.performance_check' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - performance check enabled: $PERFORMANCE_CHECK"
+echo "[$(date)][INFO] Configuration - performance check enabled: $PERFORMANCE_CHECK"
 
 HDD_PATH="$(jq --raw-output '.hdd_path' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - disk path: $HDD_PATH" 
+echo "[$(date)][INFO] Configuration - disk path: $HDD_PATH" 
 
-CHECK_PERIOD="$(jq --raw-output '.check_period' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - check period: $CHECK_PERIOD" 
+SMART_CHECK_PERIOD="$(jq --raw-output '.check_period' $CONFIG_PATH)"
+echo "[$(date)][INFO] Configuration - check period: $SMART_CHECK_PERIOD" 
+
+DATABASE_UPDATE="$(jq --raw-output '.database_update' $CONFIG_PATH)"
+echo "[$(date)][INFO] Configuration - database update: $DATABASE_UPDATE" 
+
+DATABASE_UPDATE_PERIOD="$(jq --raw-output '.database_update_period' $CONFIG_PATH)"
+echo "[$(date)][INFO] Configuration - database update period: $DATABASE_UPDATE_PERIOD" 
 
 OUTPUT_FILE="$(jq --raw-output '.output_file' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - output file: $OUTPUT_FILE"
+echo "[$(date)][INFO] Configuration - output file: $OUTPUT_FILE"
 
 ATTRIBUTES_PROPERTY="$(jq --raw-output '.attributes_property' $CONFIG_PATH)"
-echo "[$(date)][Info] Configuration - attributes property: $ATTRIBUTES_PROPERTY"
+echo "[$(date)][INFO] Configuration - attributes property: $ATTRIBUTES_PROPERTY"
 
 mkdir -p /share/hdd_tools/scripts/
 mkdir -p /share/hdd_tools/performance_test/
 cp /opt/storage.sh /share/hdd_tools/scripts/storage.sh
 cp /opt/main.sh /share/hdd_tools/scripts/main.sh
+cp /opt/database.sh /share/hdd_tools/scripts/database.sh
 
-echo "[$(date)][Info] Init run"
+echo "[$(date)][INFO] Init run"
 /share/hdd_tools/scripts/main.sh
 
 if [ "$PERFORMANCE_CHECK" = "true" ]; then
-    echo "[$(date)][Info] Run performance test"
+    echo "[$(date)][INFO] Run performance test"
     /share/hdd_tools/scripts/storage.sh /share/hdd_tools/performance_test/ > /share/hdd_tools/performance.log 2> /share/hdd_tools/performance.log
     cat /share/hdd_tools/performance.log | sed  -n '/Category/,$p'
-    echo "[$(date)][Info] Performance test end"
+    echo "[$(date)][INFO] Performance test end"
 fi
 
-echo "[$(date)][Info] Cron tab update"
-sed -i "s/TIME_TOKEN/$CHECK_PERIOD/g" /etc/cron.d/cron
+echo "[$(date)][INFO] Cron tab SMART update"
+sed -i "s/SMART_TIME_TOKEN/$SMART_CHECK_PERIOD/g" /etc/cron.d/cron
 
-echo "[$(date)][Info] Apply cron tab"
+if [ "$DATABASE_UPDATE" = "true" ]; then
+    echo "[$(date)][INFO] Cron tab database update ENABLED"
+    /share/hdd_tools/scripts/database.sh
+    sed -i "s/#\(.*\)DATABASE_TIME_TOKEN/\1$DATABASE_UPDATE_PERIOD/g" /etc/cron.d/cron
+else
+    echo "[$(date)][INFO] Cron tab database update DISABLED"
+fi
+
+echo "[$(date)][INFO] Apply cron tab"
 crontab /etc/cron.d/cron
 
 if [ -b $HDD_PATH ]; then 
-    echo "[$(date)][Info] Device $HDD_PATH found - starting CRON"    
+    echo "[$(date)][INFO] Device $HDD_PATH found - starting CRON"    
     crond -f
 else
-    echo "[$(date)][Info] Device $HDD_PATH not found - exiting"    
+    echo "[$(date)][INFO] Device $HDD_PATH not found - exiting"    
     exit 1
 fi
 

--- a/hdd_tools/translations/en.yaml
+++ b/hdd_tools/translations/en.yaml
@@ -15,8 +15,14 @@ configuration:
     name: Attributes property
     description: Attribute you want to merge with the attributes in your sensor. Check the output file for the available properties.
   check_period:
-    name: Check period
+    name: Check period (minutes)
     description: Interval in minutes / how often to read temperature
+  database_update:
+    name: Update drives database
+    description: Flag to enable the update of the smartmontools drives database
+  database_update_period:
+    name: Drives database update period (hours) 
+    description: Interval in hours / how often the drive database is updated
   performance_check:
     name: Performance check
     description: Flag to enable or disable the execution of performance check at startup

--- a/hdd_tools/translations/es.yaml
+++ b/hdd_tools/translations/es.yaml
@@ -10,7 +10,11 @@ configuration:
   attributes_property:
     name: Propiedad con los atributos
   check_period:
-    name: Intervalo de comprobación
+    name: Intervalo de comprobación (minutos)
+  database_update:
+    name: Actualizar base de datos de discos duros
+  database_update_period:
+    name: Periodo de actualización de la base de datos de discos duros (horas) 
   performance_check:
     name: Comprobar el rendimiento
   debug:


### PR DESCRIPTION
The smartmontools package, has a command to update the drives database with more up to date SMART metadata. More info here: https://www.smartmontools.org/wiki/Download#Updatethedrivedatabase

This PR adds an option to update it, by default at each restart and once a week (configurable).