### PR TITLE
Preserve permissions when copying scripts

### DIFF
--- a/hdd_tools/run.sh
+++ b/hdd_tools/run.sh
@@ -27,9 +27,9 @@ echo "[$(date)][INFO] Configuration - attributes property: $ATTRIBUTES_PROPERTY"
 
 mkdir -p /share/hdd_tools/scripts/
 mkdir -p /share/hdd_tools/performance_test/
-cp /opt/storage.sh /share/hdd_tools/scripts/storage.sh
-cp /opt/main.sh /share/hdd_tools/scripts/main.sh
-cp /opt/database.sh /share/hdd_tools/scripts/database.sh
+cp -p /opt/storage.sh /share/hdd_tools/scripts/storage.sh
+cp -p /opt/main.sh /share/hdd_tools/scripts/main.sh
+cp -p /opt/database.sh /share/hdd_tools/scripts/database.sh
 
 echo "[$(date)][INFO] Init run"
 /share/hdd_tools/scripts/main.sh


### PR DESCRIPTION
Fixes https://github.com/Draggon/hassio-hdd-tools/issues/27

This preserves the permissions of the files copied to eliminate possible issues like the one of the issue linked.

I'm not too sure if this is the "correct" fix. I'm not too sure why we are copying the scripts to a shared external folder, and not executing directly the /opt files directly. Maybe to let an easy change/test of the scripts while developing?