### PR TITLE
Add full_access option again

### DIFF
--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -11,6 +11,10 @@ This add-on provides information about HDD Temperature from S.M.A.R.T using smar
 
 Check the *Documentation* tab to get more information about `options` and `parameters`.
 
+## Notes
+
+For some devices and Home Assistant versions, the addon reguires Protection Mode to be disabled to access S.M.A.R.T data. If you see an error in the HDD Tools log try to disable Protection Mode.
+
 ## Credits
 
 - https://www.smartmontools.org/

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -9,6 +9,8 @@
   "boot": "auto",
   "map": ["share:rw"],
   "privileged": ["SYS_ADMIN", "SYS_RAWIO"],
+  "devices": ["/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde", "/dev/nvme0", "/dev/nvme1"],
+  "full_access": true,
   "homeassistant": "2021.2.0",
   "homeassistant_api": true,
   "options": {


### PR DESCRIPTION
Fixes https://github.com/Draggon/hassio-hdd-tools/issues/35

Something has changed in Home Assistant. I can't see the list of mapped `devices` in the container (using either the way where it uses the one specified by the user or the list passed in the config file), so the only way to access the smartctl data is enabling `full_access` again.

I let a list of devices mapped to see easily if at some moment Home Assistant fixes the issue (I will open a bug report without but I doubt they will take it seriously).