### PR TITLE
Add smart state as option to report in the sensor

### DIFF
--- a/hdd_tools/DOCS.md
+++ b/hdd_tools/DOCS.md
@@ -6,7 +6,8 @@
 
 | Parameter | Description |
 |-----------|-------------|
-| sensor_name | Name for the sensor which is exposed to home-assistant
+| sensor_state_type | Type of the sensor which is exposed to home-assistant. Can be `smart_state` or `temperature`.
+| sensor_name | Name for the sensor which is exposed to home-assistant. For `smart_state` it must begin with `binary_sensor.`, for `temperature` it must begin with `sensor.`.
 | friendly_name | Friendly name for the sensor which is exposed to home-assistant
 | hdd_path | Path to drive to monitor
 | attributes_format | One of `object` or `list`. See more details [here](#attributes).

--- a/hdd_tools/README.md
+++ b/hdd_tools/README.md
@@ -4,9 +4,9 @@
 
 ## General
 
-This add-on provides information about HDD Temperature from S.M.A.R.T using smartmontools.
-- Temperature is visible in Home-Assistant via sensor `sensor.hdd_temp`.
-- SMART attributes are mapped to `sensor.hdd_temp` sensor attributes.
+This add-on provides information about HDD S.M.A.R.T. values using smartmontools.
+- By default the temperature reported by S.M.A.R.T. is visible in Home Assistant via sensor `sensor.hdd_smart`, but you can select to report S.M.A.R.T. status passed value if you prefer.
+- All the S.M.A.R.T. attributes are mapped to the sensor as attributes. You can use `template` sensors in Home Assistant to publish them as sensors too.
 - Optionally, at start, add-on runs PiBenchmarks https://jamesachambers.com/raspberry-pi-storage-benchmarks-2019-benchmarking-script/ and stores output in _/share/hdd_tools/performance.log_
 
 Check the *Documentation* tab to get more information about `options` and `parameters`.

--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -2,7 +2,7 @@
   "name": "HDD Tools",
   "version": "0.51.0",
   "slug": "hdd_tools",
-  "description": "HDD Tools provides S.M.A.R.T information",
+  "description": "HDD Tools provides S.M.A.R.T. information",
   "url": "https://github.com/Draggon/hassio-hdd-tools",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
@@ -14,8 +14,9 @@
   "homeassistant": "2021.2.0",
   "homeassistant_api": true,
   "options": {
-      "sensor_name": "sensor.hdd_temp",
-      "friendly_name": "Hdd Temp",
+      "sensor_state_type": "temperature",
+      "sensor_name": "sensor.hdd_smart",
+      "friendly_name": "Hdd SMART",
       "hdd_path": "/dev/sda",
       "attributes_format": "object",
       "attributes_property": "",
@@ -27,7 +28,8 @@
       "output_file": "temp.log"
   },
   "schema": {
-      "sensor_name": "match(^sensor\\.\\w*$)",
+      "sensor_state_type": "list(smart_state|temperature)",
+      "sensor_name": "match(^(sensor|binary_sensor)\\.\\w*$)",
       "friendly_name": "str",
       "hdd_path": "device(subsystem=block)",
       "attributes_format": "list(object|list)",

--- a/hdd_tools/run.sh
+++ b/hdd_tools/run.sh
@@ -4,6 +4,9 @@ echo "[$(date)][INFO] HDD Tools start"
 
 CONFIG_PATH=/data/options.json
 
+SENSOR_STATE_TYPE="$(jq --raw-output '.sensor_state_type' $CONFIG_PATH)"
+echo "[$(date)][INFO] Configuration - sensor state type: $SENSOR_STATE_TYPE"
+
 PERFORMANCE_CHECK="$(jq --raw-output '.performance_check' $CONFIG_PATH)"
 echo "[$(date)][INFO] Configuration - performance check enabled: $PERFORMANCE_CHECK"
 

--- a/hdd_tools/translations/en.yaml
+++ b/hdd_tools/translations/en.yaml
@@ -1,7 +1,10 @@
 configuration:
+  sensor_state_type:
+    name: Sensor type
+    description: Sensor value to expose to Home Assistant, can be temperature or smart_state
   sensor_name:
     name: Name of the sensor
-    description: Name for the sensor which is exposed to Home Assistant    
+    description: Name for the sensor which is exposed to Home Assistant
   friendly_name:
     name: Friendly name
     description: Friendly name for the sensor which is exposed to Home Assistant

--- a/hdd_tools/translations/es.yaml
+++ b/hdd_tools/translations/es.yaml
@@ -1,4 +1,6 @@
 configuration:
+  sensor_state_type:
+    name: Tipo de sensor
   sensor_name:
     name: Nombre del sensor
   friendly_name:


### PR DESCRIPTION
Fixes https://github.com/Draggon/hassio-hdd-tools/issues/45 and https://github.com/Draggon/hassio-hdd-tools/issues/32

Adds an option to select if we want the "temperature" as state of the sensor, or the smart status and publish it as a problem binary sensor.

![image](https://user-images.githubusercontent.com/2673520/147659125-7c29ac1c-479f-4370-ba09-096bdcb2a067.png)

CAUTION: If you select the smart state, you must change the name of the sensor by a binary_sensor. An error is raised in the log of the addon to inform about this.

If some user wants more than one, can select the smart status and use the Home Assistant template sensor to generate the others using the attributes.


