### PR TITLE
Fix s6-overlay-suexec: fatal

### DIFF
--- a/hdd_tools/config.json
+++ b/hdd_tools/config.json
@@ -7,6 +7,7 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
   "boot": "auto",
+  "init": false,
   "map": ["share:rw"],
   "privileged": ["SYS_ADMIN", "SYS_RAWIO"],
   "full_access": true,


### PR DESCRIPTION
Fixes https://github.com/Draggon/hassio-hdd-tools/issues/53

Since Home Assistant 2022.5.5 the Addon does not work anymore, here is the information https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/

Thanks to @alexbelgium for point me to the solution!!